### PR TITLE
Fix map::at() const issue, by making RingBuffer operator+/- const

### DIFF
--- a/ArxContainer.h
+++ b/ArxContainer.h
@@ -96,19 +96,19 @@ class RingBuffer {
             return ptr + index();
         }
 
-        Iterator operator+(const Iterator& rhs) {
+        Iterator operator+(const Iterator& rhs) const {
             Iterator it(this->ptr, this->pos + rhs.pos);
             return it;
         }
-        Iterator operator+(const int n) {
+        Iterator operator+(const int n) const {
             Iterator it(this->ptr, this->pos + n);
             return it;
         }
-        Iterator operator-(const Iterator& rhs) {
+        Iterator operator-(const Iterator& rhs) const {
             Iterator it(this->ptr, this->pos - rhs.pos);
             return it;
         }
-        Iterator operator-(const int n) {
+        Iterator operator-(const int n) const {
             Iterator it(this->ptr, this->pos - n);
             return it;
         }

--- a/examples/map/map.ino
+++ b/examples/map/map.ino
@@ -4,11 +4,7 @@
 arx::map<String, int> mp {{"one", 1}, {"two", 2}, {"four", 4}};
 
 void setup() {
-#ifdef NANO_OLD_BOOTLOADER // for rubbish nano clones with slow USB
-    Serial.begin(38400);
-#else
     Serial.begin(115200);
-#endif
     delay(2000);
 
     // add contents
@@ -39,20 +35,11 @@ void setup() {
     Serial.println(mp["five"]);
 
     // const ref access
-    /*
-     * In file included from /home/xxxx/git/Arduino_ArxContainer/examples/map/map.ino:1:0:
-/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h: In instantiation of 'arx::map<Key, T, N>::const_iterator arx::map<Key, T, N>::find(const Key&) const [with Key = String; T = int; unsigned int N = 16; arx::map<Key, T, N>::const_iterator = const arx::RingBuffer<arx::pair<String, int>, 16>::Iterator]':
-/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h:709:20:   required from 'const T& arx::map<Key, T, N>::at(const Key&) const [with Key = String; T = int; unsigned int N = 16]'
-/home/xxxx/git/Arduino_ArxContainer/examples/map/map.ino:50:34:   required from here
-/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h:659:47: warning: passing 'arx::RingBuffer<arx::pair<String, int>, 16>::const_iterator {aka const arx::RingBuffer<arx::pair<String, int>, 16>::Iterator}' as 'this' argument discards qualifiers [-fpermissive]
-             const_iterator it = this->begin() + i;
-/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h:103:18: note:   in call to 'arx::RingBuffer<T, N>::Iterator arx::RingBuffer<T, N>::Iterator::operator+(int) [with T = arx::pair<String, int>; unsigned int N = 16]'
-         Iterator operator+(const int n) {
-                  ^~~~~~~~
-     */
     const auto& mp_ro = mp;   
     Serial.print("const map one   = ");
     Serial.println(mp_ro.at("one"));
+    Serial.print("const map four  = ");
+    Serial.println(mp_ro.at("four"));
 }
 
 void loop() {

--- a/examples/map/map.ino
+++ b/examples/map/map.ino
@@ -4,7 +4,11 @@
 arx::map<String, int> mp {{"one", 1}, {"two", 2}, {"four", 4}};
 
 void setup() {
+#ifdef NANO_OLD_BOOTLOADER // for rubbish nano clones with slow USB
+    Serial.begin(38400);
+#else
     Serial.begin(115200);
+#endif
     delay(2000);
 
     // add contents
@@ -33,6 +37,22 @@ void setup() {
     Serial.println(mp["four"]);
     Serial.print("five  = ");
     Serial.println(mp["five"]);
+
+    // const ref access
+    /*
+     * In file included from /home/xxxx/git/Arduino_ArxContainer/examples/map/map.ino:1:0:
+/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h: In instantiation of 'arx::map<Key, T, N>::const_iterator arx::map<Key, T, N>::find(const Key&) const [with Key = String; T = int; unsigned int N = 16; arx::map<Key, T, N>::const_iterator = const arx::RingBuffer<arx::pair<String, int>, 16>::Iterator]':
+/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h:709:20:   required from 'const T& arx::map<Key, T, N>::at(const Key&) const [with Key = String; T = int; unsigned int N = 16]'
+/home/xxxx/git/Arduino_ArxContainer/examples/map/map.ino:50:34:   required from here
+/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h:659:47: warning: passing 'arx::RingBuffer<arx::pair<String, int>, 16>::const_iterator {aka const arx::RingBuffer<arx::pair<String, int>, 16>::Iterator}' as 'this' argument discards qualifiers [-fpermissive]
+             const_iterator it = this->begin() + i;
+/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h:103:18: note:   in call to 'arx::RingBuffer<T, N>::Iterator arx::RingBuffer<T, N>::Iterator::operator+(int) [with T = arx::pair<String, int>; unsigned int N = 16]'
+         Iterator operator+(const int n) {
+                  ^~~~~~~~
+     */
+    const auto& mp_ro = mp;   
+    Serial.print("const map one   = ");
+    Serial.println(mp_ro.at("one"));
 }
 
 void loop() {


### PR DESCRIPTION
adding following code at end of setup() iin map.ino
```
    const auto& mp_ro = mp;   
    Serial.print("const map one   = ");
    Serial.println(mp_ro.at("one"));
```
results in horrible warnings like
```
     In file included from /home/xxxx/git/Arduino_ArxContainer/examples/map/map.ino:1:0:
/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h: In instantiation of 'arx::map<Key, T, N>::const_iterator arx::map<Key, T, N>::find(const Key&) const [with Key = String; T = int; unsigned int N = 16; arx::map<Key, T, N>::const_iterator = const arx::RingBuffer<arx::pair<String, int>, 16>::Iterator]':
/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h:709:20:   required from 'const T& arx::map<Key, T, N>::at(const Key&) const [with Key = String; T = int; unsigned int N = 16]'
/home/xxxx/git/Arduino_ArxContainer/examples/map/map.ino:50:34:   required from here
/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h:659:47: warning: passing 'arx::RingBuffer<arx::pair<String, int>, 16>::const_iterator {aka const arx::RingBuffer<arx::pair<String, int>, 16>::Iterator}' as 'this' argument discards qualifiers [-fpermissive]
             const_iterator it = this->begin() + i;
/home/xxxx/git/yyyy/libraries/ArxContainer/ArxContainer.h:103:18: note:   in call to 'arx::RingBuffer<T, N>::Iterator arx::RingBuffer<T, N>::Iterator::operator+(int) [with T = arx::pair<String, int>; unsigned int N = 16]'
         Iterator operator+(const int n) {
                  ^~~~~~~~
```
This is because map's `const T& at(const Key& key) const`  is using `find(key)` which is `const_iterator find(const Key& key) const` but that uses `this->begin() + i` which is NOT `const`. 
So I have made `RingBuffer::Iterator operator+` (and `operator-`) into `const` functions.
Note that the baudrate changes to `map.ino` are for my El Cheapo nano clones which won't work above 38K4. Those lines can be discarded. 