### PR TITLE
A lot of bugfixes, corrected iterator changes from #5, lowered memory overhead per object

### DIFF
--- a/ArxContainer.h
+++ b/ArxContainer.h
@@ -408,40 +408,56 @@ public:
         }
     }
 
+    // https://en.cppreference.com/w/cpp/container/vector/insert
     void insert(const_iterator pos, const_iterator first, const_iterator last) {
-        if (pos != end()) {
-            size_t sz = 0;
-            {
-                for (iterator it = first; it != last; ++it) ++sz;
-            }
-            iterator it = end() + sz - 1;
-            for (int i = sz; i > 0; --i, --it)
-                *it = *(it - sz);
-            it = pos;
-            for (size_t i = 0; i < sz; ++i)
-                *it = *(first + i);
-        } else {
-            for (iterator it = first; it != last; ++it)
-                push_back(*it);
+        if (!is_valid(pos) && pos != end())
+            return;
+
+        size_t sz = 0;
+        {
+            for (const_iterator it = first; it != last; ++it) ++sz;
+        }
+        size_t new_sz = size() + sz;
+        if (new_sz > capacity())
+            new_sz = capacity();
+
+        iterator it = begin() + new_sz - 1;
+        while (it != pos) {
+            *it = *(it - sz);
+            --it;
+        }
+        for (size_t i = 0; i < sz; ++i) {
+            *(iterator)(it + i) = *(first + i);
+            if (size() < capacity() || (it + i) == end())
+                increment_tail();
         }
     }
 
     void insert(const_iterator pos, const T* first, const T* last) {
-        if (pos != end()) {
-            size_t sz = 0;
-            {
-                for (const T* it = first; it != last; ++it) ++sz;
-            }
-            iterator it = end() + sz - 1;
-            for (int i = sz; i > 0; --i, --it)
-                *it = *(it - sz);
-            it = pos;
-            for (size_t i = 0; i < sz; ++i)
-                *it = *(first + i);
-        } else {
-            for (const T* it = first; it != last; ++it)
-                push_back(*it);
+        if (!is_valid(pos) && pos != end())
+            return;
+
+        size_t sz = last - first;
+
+        size_t new_sz = size() + sz;
+        if (new_sz > capacity())
+            new_sz = capacity();
+            
+        iterator it = begin() + new_sz - 1;
+        while (it != pos) {
+            *it = *(it - sz);
+            --it;
         }
+        for (size_t i = 0; i < sz; ++i) {
+            *(iterator)(it + i) = *(first + i);
+            if (size() < capacity() || (it + i) == end())
+                increment_tail();
+        }
+    }
+
+    void insert(const_iterator pos, const T& val) {
+        const T* ptr = &val;
+        insert(pos, ptr, ptr + 1);
     }
 
 private:

--- a/ArxContainer.h
+++ b/ArxContainer.h
@@ -68,19 +68,21 @@ class RingBuffer {
             this->pos = container::detail::move(it.pos);
         }
 
-        int index() const {
+    private:
+        static int pos_wrap_around(const int pos) {
             if (pos >= 0)
                 return pos % N;
             else
-                return N - (abs(pos) % (N + 1));
+                return (N - 1) - (abs(pos + 1) % N);
+        }
+
+    public:
+        int index() const {
+            return pos_wrap_around(pos);
         }
 
         int index_with_offset(const int i) const {
-            const int p = pos + i;
-            if (p >= 0)
-                return p % N;
-            else
-                return N - (abs(p) % (N + 1));
+            return pos_wrap_around(pos + i);
         }
 
         const T& operator*() const {

--- a/ArxContainer.h
+++ b/ArxContainer.h
@@ -391,9 +391,9 @@ public:
 
     void resize(size_t sz) {
         size_t s = size();
-        if (sz > size()) {
+        if (sz > s) {
             for (size_t i = 0; i < sz - s; ++i) push(T());
-        } else if (sz < size()) {
+        } else if (sz < s) {
             for (size_t i = 0; i < s - sz; ++i) pop();
         }
     }
@@ -405,7 +405,6 @@ public:
 
     void assign(const T* first, const T* end) {
         clear();
-        // T* it = first;
         while (first != end) push(*(first++));
     }
 
@@ -419,11 +418,8 @@ public:
     }
 
     void fill(const T& v) {
-        iterator it = begin();
-        while (it != end()) {
+        for (iterator it = begin(); it != end(); ++it)
             *it = v;
-            ++it;
-        }
     }
 
     // https://en.cppreference.com/w/cpp/container/vector/insert
@@ -530,7 +526,7 @@ private:
         else if (head_ <= (static_cast<int>(INT_MIN) + static_cast<int>(capacity())) \
                 || tail_ >= (static_cast<int>(INT_MAX) - static_cast<int>(capacity()))) {
             // +/- capacity(): reserve some space for pointer/iterator arithmetics
-            // pointer are newly set N+1 steps before the overflow occurs
+            // head_/tail_ pointers are re-set N+1 steps before the overflow occurs
             int len = size();
             head_ = begin().index();
             tail_ = head_ + len;

--- a/ArxContainer.h
+++ b/ArxContainer.h
@@ -272,16 +272,18 @@ public:
     : queue_()
     , head_(r.head_)
     , tail_(r.tail_) {
+        const_iterator it = r.begin();
         for (size_t i = 0; i < r.size(); ++i) {
-            int pos = r.begin().index_with_offset(i);
+            int pos = it.index_with_offset(i);
             queue_[pos] = r.queue_[pos];
         }
     }
     RingBuffer& operator=(const RingBuffer& r) {
         head_ = r.head_;
         tail_ = r.tail_;
+        const_iterator it = r.begin();
         for (size_t i = 0; i < r.size(); ++i) {
-            int pos = r.begin().index_with_offset(i);
+            int pos = it.index_with_offset(i);
             queue_[pos] = r.queue_[pos];
         }
         return *this;
@@ -291,8 +293,9 @@ public:
     RingBuffer(RingBuffer&& r) {
         head_ = container::detail::move(r.head_);
         tail_ = container::detail::move(r.tail_);
+        const_iterator it = r.begin();
         for (size_t i = 0; i < r.size(); ++i) {
-            int pos = r.begin().index_with_offset(i);
+            int pos = it.index_with_offset(i);
             queue_[pos] = container::detail::move(r.queue_[pos]);
         }
     }
@@ -300,8 +303,9 @@ public:
     RingBuffer& operator=(RingBuffer&& r) {
         head_ = container::detail::move(r.head_);
         tail_ = container::detail::move(r.tail_);
+        const_iterator it = r.begin();
         for (size_t i = 0; i < r.size(); ++i) {
-            int pos = r.begin().index_with_offset(i);
+            int pos = it.index_with_offset(i);
             queue_[pos] = container::detail::move(r.queue_[pos]);
         }
         return *this;

--- a/ArxContainer.h
+++ b/ArxContainer.h
@@ -324,12 +324,12 @@ public:
         increment_tail();
     };
     void push_front(const T& data) {
-        get(head_) = data;
         decrement_head();
+        get(head_) = data;
     };
     void push_front(T&& data) {
-        get(head_) = data;
         decrement_head();
+        get(head_) = data;
     };
     void emplace(const T& data) { push(data); }
     void emplace(T&& data) { push(data); }

--- a/ArxContainer.h
+++ b/ArxContainer.h
@@ -511,11 +511,13 @@ private:
     void resolve_overflow() {
         if (empty())
             clear();
-        else if (head_.raw_pos() > tail_.raw_pos()) {
-            // the same value will be obtained regardless of which of the head tail overflows
-            int len = (INT_MAX - head_.raw_pos()) + (tail_.raw_pos() - INT_MIN);
-            clear();
-            tail_.set(len);
+        else if (head_.raw_pos() <= ((int)INT_MIN + (int)capacity()) \
+                || tail_.raw_pos() >= ((int)INT_MAX - (int)capacity())) {
+            // +/- capacity(): reserve some space for pointer/iterator arithmetics
+            // pointer are newly set N+1 steps before the overflow occurs
+            int len = size();
+            head_.set(begin().index());
+            tail_.set(head_.raw_pos() + len);
         }
     }
 

--- a/ArxContainer.h
+++ b/ArxContainer.h
@@ -254,14 +254,18 @@ public:
     : queue_()
     , head_(queue_, r.head_.raw_pos())
     , tail_(queue_, r.tail_.raw_pos()) {
-        for (size_t i = 0; i < r.size(); ++i)
-            queue_[i] = r.queue_[i];
+        for (size_t i = 0; i < r.size(); ++i) {
+            int pos = ConstIterator::pos_wrap_around(r.head_.raw_pos() + (int)i);
+            queue_[pos] = r.queue_[pos];
+        }
     }
     RingBuffer& operator=(const RingBuffer& r) {
         head_.set(r.head_.raw_pos());
         tail_.set(r.tail_.raw_pos());
-        for (size_t i = 0; i < r.size(); ++i)
-            queue_[i] = r.queue_[i];
+        for (size_t i = 0; i < r.size(); ++i) {
+            int pos = ConstIterator::pos_wrap_around(r.head_.raw_pos() + (int)i);
+            queue_[pos] = r.queue_[pos];
+        }
         return *this;
     }
 
@@ -269,15 +273,19 @@ public:
     RingBuffer(RingBuffer&& r) {
         head_ = container::detail::move(r.head_);
         tail_ = container::detail::move(r.tail_);
-        for (size_t i = 0; i < r.size(); ++i)
-            queue_[i] = container::detail::move(r.queue_[i]);
+        for (size_t i = 0; i < r.size(); ++i) {
+            int pos = ConstIterator::pos_wrap_around(r.head_.raw_pos() + (int)i);
+            queue_[pos] = container::detail::move(r.queue_[pos]);
+        }
     }
 
     RingBuffer& operator=(RingBuffer&& r) {
         head_ = container::detail::move(r.head_);
         tail_ = container::detail::move(r.tail_);
-        for (size_t i = 0; i < r.size(); ++i)
-            queue_[i] = container::detail::move(r.queue_[i]);
+        for (size_t i = 0; i < r.size(); ++i) {
+            int pos = ConstIterator::pos_wrap_around(r.head_.raw_pos() + (int)i);
+            queue_[pos] = container::detail::move(r.queue_[pos]);
+        }
         return *this;
     }
 


### PR DESCRIPTION
* #10 - bugfix in push_front()
* #11 - bugfix in index() calculation from negative pos
* #12 - bugfix in copy constructor and operator=()
* #13 - bugfix in insert()
* #14 - bugfix in resolve_overflow()
* #15 - corrected work with iterators that started in #5 and #6
* #16 - saved memory overhead per object (10 => 4 bytes on Arduino Nano)
* some minor improvements