### PR TITLE
Add visibility back to deque::begin, end, emplace, assign

### DIFF
--- a/ArxContainer.h
+++ b/ArxContainer.h
@@ -704,10 +704,10 @@ private:
     using RingBuffer<T, N>::capacity;
     using RingBuffer<T, N>::pop;
     using RingBuffer<T, N>::push;
-    using RingBuffer<T, N>::emplace;
-    using RingBuffer<T, N>::assign;
-    using RingBuffer<T, N>::begin;
-    using RingBuffer<T, N>::end;
+    // NO! deque DOES have this! // using RingBuffer<T, N>::emplace;
+    // NO! deque DOES have this! // using RingBuffer<T, N>::assign;
+    // NO! deque DOES have this! // using RingBuffer<T, N>::begin;
+    // NO! deque DOES have this! // using RingBuffer<T, N>::end;
     using RingBuffer<T, N>::fill;
 };
 


### PR DESCRIPTION
C++ std::deque has begin(), end(), and a few other methods visible, that are hidden with ArxContainer. 
This means that STL code for iterating deque collections, that works with std::, will fail with ArxContainer.
This PR stops those methods from being hidden.
It has been tested with begin() and end().